### PR TITLE
Correction de bug dans l'exemple de removeEventListener

### DIFF
--- a/chat/script.js
+++ b/chat/script.js
@@ -85,18 +85,18 @@ messageContainer.addEventListener("click", (event) => {
     }
 });
 
+const copyToInput = function (event) {
+    // Prévenir l'affichage du menu contextuel avec bouton droit
+    event.preventDefault();
+
+    // readText est asynchrone et on doit attendre la fin de son exécution
+    window.navigator.clipboard.readText().
+        then(text => this.value = text);
+};
+
 /// Ajout et retrait des gestionnaires dynamique
 document.getElementById("copy-checkbox").addEventListener('change', (event) => {
     const messageInput = document.getElementById("message-input");
-
-    const copyToInput = function (event) {
-        // Prévenir l'affichage du menu contextuel avec bouton droit
-        event.preventDefault();
-
-        // readText est asynchrone et on doit attendre la fin de son exécution
-        window.navigator.clipboard.readText().
-            then(text => this.value = text);
-    };
     if (event.target.checked) {
         messageInput.addEventListener('contextmenu', copyToInput);
     }


### PR DESCRIPTION
Correction de problème avec l'exemple de `removeEventListener` dans l'exemple `chat`.

Dans la version initiale, la fonction `copyToInput` est créée à chaque exécution du callback. La référence passée dans `addEventListener` n'est donc pas la même que la référence passée dans `removeEventListener`.

La solution est de sortir la création de la fonction dans une variable qui ne change pas à chaque lancement de l'événement `change`.